### PR TITLE
Feature: generate ROS2 compatible type naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+### Eclipse ###
+bin/
+.settings/
+.classpath
+.project
+
 ### Gradle ###
 .gradle
 build/

--- a/src/main/java/com/eprosima/fastcdr/idl/context/Context.java
+++ b/src/main/java/com/eprosima/fastcdr/idl/context/Context.java
@@ -43,6 +43,8 @@ public interface Context
 
     public boolean isGenerateTypesC();
 
+    public boolean isGenerateTypesROS2();
+
     public boolean isCdr();
 
     public boolean isFastcdr();

--- a/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
+++ b/src/main/java/com/eprosima/fastrtps/fastrtpsgen.java
@@ -102,6 +102,9 @@ public class fastrtpsgen {
     //! Default package used in Java files.
     private String m_package = "";
 
+    // Generates type naming compatible with ROS 2
+    private boolean m_type_ros2 = false;
+
     // Generate TypeObject files?
     private boolean m_type_object_files = false;
 
@@ -218,6 +221,10 @@ public class fastrtpsgen {
             else if(arg.equals("-fusion"))
             {
                 fusion_ = true;
+            }
+            else if(arg.equals("-typeros2"))
+            {
+                m_type_ros2 = true;
             }
             else if(arg.equals("-typeobject"))
             {
@@ -446,6 +453,7 @@ public class fastrtpsgen {
         System.out.println("\t\t-replace: replaces existing generated files.");
         System.out.println("\t\t-ppDisable: disables the preprocessor.");
         System.out.println("\t\t-ppPath: specifies the preprocessor path.");
+        System.out.println("\t\t-typeros2: generates type naming compatible with ROS2.");
         System.out.println("\t\t-I <path>: add directory to preprocessor include paths.");
         System.out.println("\t\t-d <path>: sets an output directory for generated files.");
         System.out.println("\t\t-t <temp dir>: sets a specific directory as a temporary directory.");
@@ -516,7 +524,7 @@ public class fastrtpsgen {
         }
 
         if (idlParseFileName != null) {
-            Context ctx = new Context(onlyFileName, idlFilename, m_includePaths, m_subscribercode, m_publishercode, m_localAppProduct, m_type_object_files, m_typesc);
+            Context ctx = new Context(onlyFileName, idlFilename, m_includePaths, m_subscribercode, m_publishercode, m_localAppProduct, m_type_object_files, m_typesc, m_type_ros2);
 
             if(m_case_sensitive)
             {

--- a/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java
@@ -36,7 +36,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 {
     // TODO Remove middleware parameter. It is temporal while cdr and rest don't have async functions.
     public Context(String filename, String file, ArrayList<String> includePaths, boolean subscribercode, boolean publishercode,
-            String appProduct, boolean generate_type_object, boolean generate_typesc)
+            String appProduct, boolean generate_type_object, boolean generate_typesc, boolean generate_type_ros2)
     {
         super(filename, file, includePaths);
         m_fileNameUpper = filename.toUpperCase();
@@ -51,6 +51,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 
         m_type_object = generate_type_object;
         m_typesc = generate_typesc;
+        m_type_ros2 = generate_type_ros2;
     }
 
     public void setTypelimitation(String lt)
@@ -299,6 +300,8 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
 
     private boolean m_typesc = false;
 
+    private boolean m_type_ros2 = false;
+
     @Override
     public boolean isGenerateTypeObject()
     {
@@ -309,6 +312,12 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     public boolean isGenerateTypesC()
     {
         return m_typesc;
+    }
+
+    @Override
+    public boolean isGenerateTypesROS2()
+    {
+        return m_type_ros2;
     }
 
     public String getHeaderGuardName ()

--- a/src/main/java/com/eprosima/fastrtps/idl/templates/RTPSPubSubTypeSource.stg
+++ b/src/main/java/com/eprosima/fastrtps/idl/templates/RTPSPubSubTypeSource.stg
@@ -68,7 +68,7 @@ typedef_decl(ctx, parent, typedefs) ::= <<>>
 struct_type(ctx, parent, struct) ::= <<
 $if(parent.IsInterface)$$parent.name$_$endif$$struct.name$PubSubType::$if(parent.IsInterface)$$parent.name$_$endif$$struct.name$PubSubType()
 {
-    setName("$struct.scopedname$");
+    $if(ctx.GenerateTypesROS2)$    setName("$struct.ROS2Scopedname$");$else$    setName("$struct.scopedname$");$endif$
     m_typeSize = static_cast<uint32_t>($if(parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$::getMaxCdrSerializedSize()) + 4 /*encapsulation*/;
     m_isGetKeyDefined = $if(parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$::isKeyDefined();
     size_t keyLength = $if(parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$::getKeyMaxCdrSerializedSize()>16 ? $if(parent.IsInterface)$$struct.scopedname$$else$$struct.name$$endif$::getKeyMaxCdrSerializedSize() : 16;


### PR DESCRIPTION
Fixes https://github.com/eProsima/Fast-RTPS-Gen/issues/19. @LuisGP thank you for the tips. Please check if this solution makes sense to you:

1.  `-typeros2` option sets `m_type_ros2` to `true`, which is defined in the Context;
1.  If `isGenerateTypesROS2` is true,  meaning `m_type_ros2`, then it's used a scoped name generated from the IDL parser, which has the required valid structure to be used in the ROS2 context.

Requires https://github.com/eProsima/IDL-Parser/pull/39 to be merged first.