### PR TITLE
Context: fix warning on unchecked method invocation for AbstractMap.SimpleEntry<String, TypeCode>

### DIFF
--- a/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java
+++ b/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java
@@ -160,7 +160,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
     private void getSequencesToDefine(ArrayList<Entry<String, TypeCode>> typecodes, SequenceTypeCode sequence)
     {
         // Search
-        for (Entry entry : typecodes)
+        for (Entry<String, TypeCode> entry : typecodes)
         {
             if (entry.getKey().equals(sequence.getCppTypename()))
             {
@@ -187,7 +187,7 @@ public class Context extends com.eprosima.idl.context.Context implements com.epr
             }
         }
 
-        typecodes.add(new SimpleEntry(sequence.getCppTypename(), sequence));
+        typecodes.add(new SimpleEntry<String, TypeCode>(sequence.getCppTypename(), sequence));
     }
 
     /*** Functions inherated from FastCDR Context ***/


### PR DESCRIPTION
Building in Gradle 6.2, I was seeing the following warning:
```sh
> Task :compileJava
/home/nuno/Fast-RTPS-Gen/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java:190: warning: [unchecked] unchecked call to SimpleEntry(K,V) as a member of the raw type SimpleEntry
        typecodes.add(new SimpleEntry(sequence.getCppTypename(), sequence));
                      ^
  where K,V are type-variables:
    K extends Object declared in class SimpleEntry
    V extends Object declared in class SimpleEntry
/home/nuno/Fast-RTPS-Gen/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java:190: warning: [unchecked] unchecked method invocation: method add in class ArrayList is applied to given types
        typecodes.add(new SimpleEntry(sequence.getCppTypename(), sequence));
                     ^
  required: E
  found: SimpleEntry
  where E is a type-variable:
    E extends Object declared in class ArrayList
/home/nuno/Fast-RTPS-Gen/src/main/java/com/eprosima/fastrtps/idl/grammar/Context.java:190: warning: [unchecked] unchecked conversion
        typecodes.add(new SimpleEntry(sequence.getCppTypename(), sequence));
                      ^
  required: E
  found:    SimpleEntry
  where E is a type-variable:
    E extends Object declared in class ArrayList
3 warnings
```
Now fixed in this PR.

@LuisGP @richiware.