### PR TITLE
Gradle: fix test stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ repositories {
 
 dependencies {
     compile files('thirdparty/idl-parser/build/libs/idlparser-1.0.0.jar')
-    testCompile group: 'junit', name: 'junit', version: '4.+'
-    compile 'junit:junit:4.+'
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.5.2')
+    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.5.2')
 }
 
 task submodulesUpdate(type: Exec) {
@@ -102,5 +102,5 @@ compileJava {
 }
 
 test {
-    useJUnit()
+    useJUnitPlatform()
 }

--- a/src/test/java/com/eprosima/fastrtps/FastRTPSGenTest.java
+++ b/src/test/java/com/eprosima/fastrtps/FastRTPSGenTest.java
@@ -1,13 +1,13 @@
 package test.com.eprosima.fastrtps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.eprosima.integration.Command;
 import com.eprosima.integration.IDL;
 import com.eprosima.integration.TestManager;
 import com.eprosima.integration.TestManager.TestLevel;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.nio.file.Paths;

--- a/src/test/java/com/eprosima/fastrtps/FastRTPSGenTest.java
+++ b/src/test/java/com/eprosima/fastrtps/FastRTPSGenTest.java
@@ -34,7 +34,7 @@ public class FastRTPSGenTest
         }
 
         //Configure idl tests
-        TestManager tests = new TestManager(TestLevel.RUN, "share/fastrtps/fastrtpsgen", INPUT_PATH,
+        TestManager tests = new TestManager(TestLevel.RUN, "share/fastrtpsgen/java/fastrtpsgen", INPUT_PATH,
                         OUTPUT_PATH + "/idls", "CMake");
         tests.removeTests(IDL.ARRAY_NESTED, IDL.SEQUENCE_NESTED);
         boolean testResult = tests.runTests();


### PR DESCRIPTION
Fixes https://github.com/eProsima/Fast-RTPS-Gen/issues/26 by:
1. Bumping the testing platform to JUnit 5 (not mandatory but might be reasonable);
2. Fixing `fastrtpsgen.jar` path in `FastRTPSGenTest.java`.

@LuisGP @richiprosima FYI review and acceptance.